### PR TITLE
Minify Razor @helper functions by implementing a build provider, resolves #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The library is also [published on NuGet.org](https://www.nuget.org/packages/Razo
 PM> Install-Package RazorHtmlMinifier.Mvc5
 ```
 
-<sup>RazorHtmlMinifier.Mvc5 is built for .NET v4.5 with a dependency on ASP.NET MVC 5.2.3.</sup>
+<sup>RazorHtmlMinifier.Mvc5 is built for .NET v4.5 with a dependency on ASP.NET MVC 5.2.3 and `System.Web`.</sup>
 
 ### Configuration
 
@@ -29,7 +29,7 @@ Find the **Web.config** with your Razor configuration (by default it's in `Views
 <host factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
 ```
 
-In order to start minifying, replace it with (after the NuGet package is installed):
+In order to start minifying views and partial views, replace it with (after the NuGet package is installed):
 
 ```xml
 <host factoryType="RazorHtmlMinifier.Mvc5.MinifyingMvcWebRazorHostFactory, RazorHtmlMinifier.Mvc5, Version=1.2.0.0, Culture=neutral, PublicKeyToken=a517a17e203fcde4" />
@@ -37,13 +37,28 @@ In order to start minifying, replace it with (after the NuGet package is install
 
 Then rebuild your solution, which should also restart the app.
 
+If you're using Razor `@helper` functions placed inside the `App_Code` folder, you have to do additional configuration in order to minify those. In the root `Web.config`, you should see something like this:
+
+```xml
+<compilation debug="true" targetFramework="4.7.2" />
+```
+
+Your `<compilation>` element might have different attributes. Leave the current attributes as-is, and add `<buildProviders>` like so:
+
+```xml
+<compilation debug="true" targetFramework="4.7.2">
+    <buildProviders>
+        <add extension=".cshtml" type="RazorHtmlMinifier.Mvc5.MinifyingRazorBuildProvider, RazorHtmlMinifier.Mvc5" />
+    </buildProviders>
+</compilation>
+```
 
 How it works
 ------------
 
 The minifier processes the code generated during Razor compilation. Because it runs in compile-time, it shouldn't add any overhead during runtime.
 
-The entire source code is just a [single file](https://github.com/tompazourek/RazorHtmlMinifier.Mvc5/blob/master/src/RazorHtmlMinifier.Mvc5/MinifyingMvcWebRazorHostFactory.cs), feel free to view it.
+The entire source code is just [two](/src/RazorHtmlMinifier.Mvc5/MinifyingMvcWebRazorHostFactory.cs) [files](/src/RazorHtmlMinifier.Mvc5/MinifyingRazorBuildProvider.cs), feel free to view them.
 
 The minification algorithm is fairly trivial. It basically:
 
@@ -67,10 +82,10 @@ I've investigated this and it looks like **VS actually needs to have the assembl
 
 If you want to add the assembly to GAC, you'll need to do the following:
 
-- Open `Developer Command Prompt for VS 2017` (you'll find it in Start menu) **as an Administrator**.
+- Open `Developer Command Prompt for VS` (you'll find it in Start menu) **as an Administrator**.
 - Navigate to the folder of the NuGet package: `cd "C:\PATH_TO_YOUR_SOLUTION\packages\RazorHtmlMinifier.Mvc5.1.2.0\lib\net45"`
 - Install it to GAC: `gacutil /i RazorHtmlMinifier.Mvc5.dll` (it should respond `Assembly successfully added to the cache`)
-- Restart VS 2017 (and maybe also clear any ReSharper caches if you're using that)
+- Restart Visual Studio (and maybe also clear any ReSharper caches if you're using that)
 
 **Then it should start working.**
 

--- a/src/RazorHtmlMinifier.Mvc5/MinifyingMvcWebRazorHostFactory.cs
+++ b/src/RazorHtmlMinifier.Mvc5/MinifyingMvcWebRazorHostFactory.cs
@@ -40,95 +40,95 @@ namespace RazorHtmlMinifier.Mvc5
                 return new MinifyingMvcCSharpRazorCodeGenerator(incomingCodeGenerator.ClassName, incomingCodeGenerator.RootNamespaceName, incomingCodeGenerator.SourceFileName, incomingCodeGenerator.Host);
             }
         }
+    }
 
-        private class MinifyingMvcCSharpRazorCodeGenerator : CSharpRazorCodeGenerator
+    internal class MinifyingMvcCSharpRazorCodeGenerator : CSharpRazorCodeGenerator
+    {
+        public MinifyingMvcCSharpRazorCodeGenerator(string className, string rootNamespaceName, string sourceFileName, RazorEngineHost host)
+            : base(className, rootNamespaceName, sourceFileName, host)
         {
-            public MinifyingMvcCSharpRazorCodeGenerator(string className, string rootNamespaceName, string sourceFileName, RazorEngineHost host)
-                : base(className, rootNamespaceName, sourceFileName, host)
+            if (host is MvcWebPageRazorHost mvcHost && !mvcHost.IsSpecialPage)
             {
-                if (host is MvcWebPageRazorHost mvcHost && !mvcHost.IsSpecialPage)
-                {
-                    // set base type dynamic by default
-                    var baseType = new CodeTypeReference($"{Context.Host.DefaultBaseClass}<dynamic>");
-                    Context.GeneratedClass.BaseTypes.Clear();
-                    Context.GeneratedClass.BaseTypes.Add(baseType);
-                }
+                // set base type dynamic by default
+                var baseType = new CodeTypeReference($"{Context.Host.DefaultBaseClass}<dynamic>");
+                Context.GeneratedClass.BaseTypes.Clear();
+                Context.GeneratedClass.BaseTypes.Add(baseType);
+            }
+        }
+
+        public override void VisitSpan(Span currentSpan)
+        {
+            if (currentSpan?.Kind == SpanKind.Markup)
+            {
+                VisitMarkupSpan(currentSpan);
             }
 
-            public override void VisitSpan(Span currentSpan)
-            {
-                if (currentSpan?.Kind == SpanKind.Markup)
-                {
-                    VisitMarkupSpan(currentSpan);
-                }
+            base.VisitSpan(currentSpan);
+        }
 
-                base.VisitSpan(currentSpan);
+        private void VisitMarkupSpan(Span currentMarkupSpan)
+        {
+            var builder = new SpanBuilder(currentMarkupSpan);
+            builder.ClearSymbols();
+
+            var previousMarkupSpan = currentMarkupSpan.Previous?.Kind == SpanKind.Markup ? currentMarkupSpan.Previous : null;
+            var previousSymbol = previousMarkupSpan?.Symbols.LastOrDefault();
+
+            foreach (var currentSymbol in currentMarkupSpan.Symbols)
+            {
+                VisitSymbol(currentSymbol, previousSymbol, builder);
+                previousSymbol = currentSymbol;
             }
 
-            private void VisitMarkupSpan(Span currentMarkupSpan)
+            currentMarkupSpan.ReplaceWith(builder);
+        }
+
+        private static void VisitSymbol(ISymbol currentSymbol, ISymbol previousSymbol, SpanBuilder builder)
+        {
+            if (IsSymbolWhiteSpaceOrNewLine(currentSymbol, out var currentHtmlSymbol))
             {
-                var builder = new SpanBuilder(currentMarkupSpan);
-                builder.ClearSymbols();
-
-                var previousMarkupSpan = currentMarkupSpan.Previous?.Kind == SpanKind.Markup ? currentMarkupSpan.Previous : null;
-                var previousSymbol = previousMarkupSpan?.Symbols.LastOrDefault();
-
-                foreach (var currentSymbol in currentMarkupSpan.Symbols)
+                if (IsSymbolWhiteSpaceOrNewLine(previousSymbol, out var _))
                 {
-                    VisitSymbol(currentSymbol, previousSymbol, builder);
-                    previousSymbol = currentSymbol;
-                }
-
-                currentMarkupSpan.ReplaceWith(builder);
-            }
-
-            private static void VisitSymbol(ISymbol currentSymbol, ISymbol previousSymbol, SpanBuilder builder)
-            {
-                if (IsSymbolWhiteSpaceOrNewLine(currentSymbol, out var currentHtmlSymbol))
-                {
-                    if (IsSymbolWhiteSpaceOrNewLine(previousSymbol, out var _))
-                    {
-                        // both current and previous symbols are whitespace/newline, we can skip current symbol
-                        return;
-                    }
-
-                    // current symbol is whitespace/newline, previous is not, we'll replace current with the smallest
-                    var replacementSymbol = GetReplacementSymbol(currentHtmlSymbol);
-                    builder.Accept(replacementSymbol);
+                    // both current and previous symbols are whitespace/newline, we can skip current symbol
                     return;
                 }
 
-                builder.Accept(currentSymbol);
+                // current symbol is whitespace/newline, previous is not, we'll replace current with the smallest
+                var replacementSymbol = GetReplacementSymbol(currentHtmlSymbol);
+                builder.Accept(replacementSymbol);
+                return;
             }
 
-            private static bool IsSymbolWhiteSpaceOrNewLine(ISymbol symbol, out HtmlSymbol outputHtmlSymbol)
-            {
-                if (symbol is HtmlSymbol htmlSymbol)
-                {
-                    if (htmlSymbol.Type == HtmlSymbolType.WhiteSpace || htmlSymbol.Type == HtmlSymbolType.NewLine)
-                    {
-                        outputHtmlSymbol = htmlSymbol;
-                        return true;
-                    }
-                }
+            builder.Accept(currentSymbol);
+        }
 
-                outputHtmlSymbol = null;
-                return false;
+        private static bool IsSymbolWhiteSpaceOrNewLine(ISymbol symbol, out HtmlSymbol outputHtmlSymbol)
+        {
+            if (symbol is HtmlSymbol htmlSymbol)
+            {
+                if (htmlSymbol.Type == HtmlSymbolType.WhiteSpace || htmlSymbol.Type == HtmlSymbolType.NewLine)
+                {
+                    outputHtmlSymbol = htmlSymbol;
+                    return true;
+                }
             }
 
-            private static HtmlSymbol GetReplacementSymbol(HtmlSymbol htmlSymbol)
+            outputHtmlSymbol = null;
+            return false;
+        }
+
+        private static HtmlSymbol GetReplacementSymbol(HtmlSymbol htmlSymbol)
+        {
+            switch (htmlSymbol.Type)
             {
-                switch (htmlSymbol.Type)
-                {
-                    case HtmlSymbolType.WhiteSpace:
-                        // any amount of whitespace is replaced with a single space
-                        return new HtmlSymbol(htmlSymbol.Start, " ", HtmlSymbolType.WhiteSpace, htmlSymbol.Errors);
-                    case HtmlSymbolType.NewLine:
-                        // newline is replaced with just \n
-                        return new HtmlSymbol(htmlSymbol.Start, "\n", HtmlSymbolType.NewLine, htmlSymbol.Errors);
-                    default:
-                        throw new ArgumentException($"Expected either {HtmlSymbolType.WhiteSpace} or {HtmlSymbolType.NewLine} symbol, {htmlSymbol.Type} given.");
-                }
+                case HtmlSymbolType.WhiteSpace:
+                    // any amount of whitespace is replaced with a single space
+                    return new HtmlSymbol(htmlSymbol.Start, " ", HtmlSymbolType.WhiteSpace, htmlSymbol.Errors);
+                case HtmlSymbolType.NewLine:
+                    // newline is replaced with just \n
+                    return new HtmlSymbol(htmlSymbol.Start, "\n", HtmlSymbolType.NewLine, htmlSymbol.Errors);
+                default:
+                    throw new ArgumentException($"Expected either {HtmlSymbolType.WhiteSpace} or {HtmlSymbolType.NewLine} symbol, {htmlSymbol.Type} given.");
             }
         }
     }

--- a/src/RazorHtmlMinifier.Mvc5/MinifyingRazorBuildProvider.cs
+++ b/src/RazorHtmlMinifier.Mvc5/MinifyingRazorBuildProvider.cs
@@ -1,0 +1,35 @@
+﻿using System.Web.Razor.Generator;
+using System.Web.WebPages.Razor;
+
+namespace RazorHtmlMinifier.Mvc5
+{
+    public class MinifyingRazorBuildProvider : RazorBuildProvider
+    {
+        protected override WebPageRazorHost GetHostFromConfig()
+        {
+            var host = base.GetHostFromConfig();
+
+            if (host is WebCodeRazorHost) // this will be true when the virtual path starts with "~/App_Code"
+            {
+                return new MinifyingWebCodeRazorHost(host.VirtualPath, host.PhysicalPath);
+            }
+
+            return host;
+        }
+
+        private class MinifyingWebCodeRazorHost : WebCodeRazorHost
+        {
+            public MinifyingWebCodeRazorHost(string virtualPath, string physicalPath) : base(virtualPath, physicalPath)
+            {
+            }
+
+            public override RazorCodeGenerator DecorateCodeGenerator(RazorCodeGenerator incomingCodeGenerator)
+            {
+                if (!(incomingCodeGenerator is CSharpRazorCodeGenerator))
+                    return base.DecorateCodeGenerator(incomingCodeGenerator);
+
+                return new MinifyingMvcCSharpRazorCodeGenerator(incomingCodeGenerator.ClassName, incomingCodeGenerator.RootNamespaceName, incomingCodeGenerator.SourceFileName, incomingCodeGenerator.Host);
+            }
+        }
+    }
+}

--- a/src/RazorHtmlMinifier.Mvc5/RazorHtmlMinifier.Mvc5.csproj
+++ b/src/RazorHtmlMinifier.Mvc5/RazorHtmlMinifier.Mvc5.csproj
@@ -32,4 +32,8 @@
     <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.3" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="System.Web" />
+  </ItemGroup>
+
 </Project>

--- a/src/RazorHtmlMinifier.Sample/App_Code/Helpers.cshtml
+++ b/src/RazorHtmlMinifier.Sample/App_Code/Helpers.cshtml
@@ -1,0 +1,30 @@
+﻿@helper Helper() {
+    <div id="lipsum-helper">
+    
+        <p>
+            Vivamus sodales fermentum auctor. Vestibulum vulputate metus vitae tellus fringilla,
+            quis laoreet purus vestibulum. Fusce a ex vitae libero auctor rutrum et quis nisi.
+            Vestibulum a mi scelerisque, laoreet urna id, blandit dui. Ut eleifend ornare erat,
+            ac rhoncus ligula elementum quis. Curabitur vulputate, lectus eu sagittis bibendum,
+            est felis fermentum ipsum, id bibendum arcu lacus vitae ante. Quisque rutrum accumsan
+            risus, ullamcorper dapibus est elementum ac. Morbi porta iaculis diam, ut mollis magna
+            maximus nec. Curabitur vestibulum tortor risus, at tincidunt eros mollis at.
+            Suspendisse pharetra leo nunc, vitae mattis urna sodales sit amet. Nam et quam molestie,
+            dignissim enim ac, facilisis ex. Donec dapibus cursus elit ac porta. Curabitur ut lorem
+            tempus, viverra magna non, aliquet orci. Suspendisse molestie arcu eget nibh iaculis,
+            vitae porta est molestie. Maecenas pharetra, nunc vitae posuere porttitor, elit lectus
+            dictum orci, a tristique dui nulla dignissim elit. Sed aliquam est vel vulputate ultrices.
+        </p>
+
+
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer quis nulla malesuada,
+            tempor augue non, ultricies arcu. Pellentesque condimentum ligula quis arcu vestibulum,
+            eget tincidunt eros sodales. Sed porta ullamcorper diam vel fermentum. Vivamus sit amet
+            laoreet erat, eleifend laoreet eros. Praesent iaculis nibh in lorem porttitor mattis.
+            Interdum et malesuada fames ac ante ipsum primis in faucibus. Aenean eleifend mauris quis
+            commodo elementum.
+        </p>
+
+    </div>
+}

--- a/src/RazorHtmlMinifier.Sample/RazorHtmlMinifier.Sample.csproj
+++ b/src/RazorHtmlMinifier.Sample/RazorHtmlMinifier.Sample.csproj
@@ -113,6 +113,7 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="App_Code\Helpers.cshtml" />
     <None Include="packages.config" />
   </ItemGroup>
   <PropertyGroup>

--- a/src/RazorHtmlMinifier.Sample/Views/Home/Index.cshtml
+++ b/src/RazorHtmlMinifier.Sample/Views/Home/Index.cshtml
@@ -6,13 +6,13 @@
     </head>
     <body>
         <div id="lipsum">
-            
+
             <p>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas aliquet vulputate
                 lectus et tincidunt. Donec non libero ligula. Ut ultrices eleifend nisl, sed faucibus
-                arcu porta non. Sed ac blandit velit, et sagittis turpis. Aenean tristique sollicitudin diam, 
-                interdum venenatis risus viverra at. Nullam non lobortis lectus. Pellentesque sagittis, arcu 
-                vel auctor mattis, erat nisl vestibulum enim, eget fermentum lorem risus nec ligula. Aliquam 
+                arcu porta non. Sed ac blandit velit, et sagittis turpis. Aenean tristique sollicitudin diam,
+                interdum venenatis risus viverra at. Nullam non lobortis lectus. Pellentesque sagittis, arcu
+                vel auctor mattis, erat nisl vestibulum enim, eget fermentum lorem risus nec ligula. Aliquam
                 aliquam ante erat, vel lobortis quam scelerisque id. In facilisis arcu non orci iaculis blandit.
             </p>
 
@@ -20,19 +20,19 @@
             <p>
                 Vestibulum et justo eros. Morbi consectetur feugiat felis, in facilisis quam malesuada non.
                 Maecenas euismod lectus vitae nibh blandit vehicula. Suspendisse ornare ante quis velit consequat,
-                ac iaculis odio tristique. Nullam ligula leo, convallis eu bibendum at, tincidunt ac libero. 
-                Vivamus luctus, tellus vitae bibendum suscipit, mi nulla laoreet urna, vitae condimentum justo ex 
-                vel sapien. Quisque ante lacus, luctus nec finibus sed, sollicitudin eget magna. Nunc ultricies 
-                quam at nisl scelerisque sagittis. Nulla urna nulla, dictum eu congue non, porttitor ut turpis. 
-                Nunc congue eleifend dui, eu pretium tellus finibus at. Duis mollis nisi a gravida sodales. 
-                Sed scelerisque blandit augue vel commodo. Nam auctor odio in ante iaculis congue. Ut vel auctor nisl. 
+                ac iaculis odio tristique. Nullam ligula leo, convallis eu bibendum at, tincidunt ac libero.
+                Vivamus luctus, tellus vitae bibendum suscipit, mi nulla laoreet urna, vitae condimentum justo ex
+                vel sapien. Quisque ante lacus, luctus nec finibus sed, sollicitudin eget magna. Nunc ultricies
+                quam at nisl scelerisque sagittis. Nulla urna nulla, dictum eu congue non, porttitor ut turpis.
+                Nunc congue eleifend dui, eu pretium tellus finibus at. Duis mollis nisi a gravida sodales.
+                Sed scelerisque blandit augue vel commodo. Nam auctor odio in ante iaculis congue. Ut vel auctor nisl.
                 Vestibulum molestie ligula vitae orci tincidunt posuere.
             </p>
-            
-            
+
+
             <p>
-                Nulla rhoncus mauris eget ligula dictum sagittis. Cras tincidunt vehicula neque, eu accumsan 
-                velit sodales nec. Nam quis sodales metus. Nulla facilisi. Pellentesque consequat feugiat tortor, 
+                Nulla rhoncus mauris eget ligula dictum sagittis. Cras tincidunt vehicula neque, eu accumsan
+                velit sodales nec. Nam quis sodales metus. Nulla facilisi. Pellentesque consequat feugiat tortor,
                 non eleifend neque cursus vel. Quisque porttitor nunc non nibh sodales, in cursus libero mattis.
                 Vivamus rutrum ultricies ornare. Nunc sed varius sapien, non porttitor nunc. Orci varius natoque
                 penatibus et magnis dis parturient montes, nascetur ridiculus mus. Sed bibendum lacus et volutpat
@@ -44,6 +44,8 @@
             </p>
 
             @Html.Partial("_Partial")
+
+            @Helpers.Helper()
 
         </div>
     </body>

--- a/src/RazorHtmlMinifier.Sample/Web.config
+++ b/src/RazorHtmlMinifier.Sample/Web.config
@@ -2,7 +2,11 @@
 
 <configuration>
     <system.web>
-        <compilation debug="true" targetFramework="4.5" />
+        <compilation debug="true" targetFramework="4.5">
+            <buildProviders>
+                <add extension=".cshtml" type="RazorHtmlMinifier.Mvc5.MinifyingRazorBuildProvider, RazorHtmlMinifier.Mvc5" />
+            </buildProviders>
+        </compilation>
         <httpRuntime targetFramework="4.5" />
     </system.web>
     <system.webServer>


### PR DESCRIPTION
See #5.

Because ASP.NET will not use the configured Razor host factory for App_Code files, a minifying build provider has been implemented. For App_Code files, ASP.NET uses `WebCodeRazorHost` instead of `MvcWebPageRazorHost`, so I have also implemented a `MinifyingWebCodeRazorHost` similar to the existing `MinifyingMvcWebPageRazorHost`.

I updated the sample and documentation. Additional configuration is required to make minification of Razor `@helper` functions work:

```xml
<compilation debug="true" targetFramework="4.7.2">
    <buildProviders>
        <add extension=".cshtml" type="RazorHtmlMinifier.Mvc5.MinifyingRazorBuildProvider, RazorHtmlMinifier.Mvc5" />
    </buildProviders>
</compilation>
```

I tested a new build of `RazorHtmlMinifier.Mvc5` in my own codebase to verify all minification works as expected.