### PR TITLE
Update version number of System.Web.Mvc in README and the sample project

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ The library is also [published on NuGet.org](https://www.nuget.org/packages/Razo
 PM> Install-Package RazorHtmlMinifier.Mvc5
 ```
 
-<sup>RazorHtmlMinifier.Mvc5 is built for .NET v4.8 with a dependency on ASP.NET MVC 5.2.7 and `System.Web`.</sup>
+<sup>RazorHtmlMinifier.Mvc5 is built for .NET v4.8 with a dependency on ASP.NET MVC 5.2.9 and `System.Web`.</sup>
 
 ### Configuration
 
 Find the **Web.config** with your Razor configuration (by default it's in `Views/Web.config`). You should see something like this inside:
 
 ```xml
-<host factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+<host factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=5.2.9.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
 ```
 
 In order to start minifying views and partial views, replace it with (after the NuGet package is installed):

--- a/src/RazorHtmlMinifier.Sample/Views/Web.config
+++ b/src/RazorHtmlMinifier.Sample/Views/Web.config
@@ -9,7 +9,7 @@
     </configSections>
 
     <system.web.webPages.razor>
-        <!--<host factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />-->
+        <!--<host factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=5.2.9.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />-->
         <host factoryType="RazorHtmlMinifier.Mvc5.MinifyingMvcWebRazorHostFactory, RazorHtmlMinifier.Mvc5" />
 
         <pages pageBaseType="System.Web.Mvc.WebViewPage">
@@ -32,7 +32,7 @@
     <system.web>
         <compilation>
             <assemblies>
-                <add assembly="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+                <add assembly="System.Web.Mvc, Version=5.2.9.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
             </assemblies>
         </compilation>
     </system.web>


### PR DESCRIPTION
This should've been part of the previous PR, my bad. No need to publish a new NuGet package version for this, right?